### PR TITLE
refactored event, progress and quanta into own modules

### DIFF
--- a/Event.elm
+++ b/Event.elm
@@ -1,0 +1,23 @@
+module Event exposing (Event, decoder)
+
+import Json.Decode as Json exposing ((:=), string, int, bool, list)
+import Json.Decode.Pipeline as JsonPipeline exposing (decode, required)
+
+
+type alias Event =
+    { precinct : String
+    , lesson : Int
+    , event_type : String
+    , canonical_student_id : Int
+    , activity : Int
+    }
+
+
+decoder : Json.Decoder Event
+decoder =
+    decode Event
+        |> JsonPipeline.required "precinct" string
+        |> JsonPipeline.required "lesson" int
+        |> JsonPipeline.required "event_type" string
+        |> JsonPipeline.required "canonical_student_id" int
+        |> JsonPipeline.optional "activity" int 0

--- a/Main.elm
+++ b/Main.elm
@@ -4,8 +4,6 @@ import Html exposing (..)
 import Html.App exposing (..)
 import Html.Attributes exposing (..)
 import Http
-import Json.Decode as Json exposing ((:=), string, int, bool, list)
-import Json.Decode.Pipeline as JsonPipeline exposing (decode, required)
 import Task
 import Material
 import Material.Scheme
@@ -14,6 +12,9 @@ import Material.Button as Button
 import Material.Table as Table
 import Material.Options exposing (css)
 import List exposing (reverse)
+import Event exposing (..)
+import Progress exposing (..)
+import Quanta exposing (..)
 
 
 main : Program Never
@@ -29,53 +30,25 @@ main =
 type Msg
     = Noop
     | GetEvents
-    | FetchSucceed (List Quanta)
+    | FetchSucceed Quanta
     | FetchFail Http.Error
     | UpdateStudentId String
     | MDL (Material.Msg Msg)
 
 
-type alias Progress =
-    { position : String
-    , placement_test : Bool
-    , map : Int
-    , activity : Int
-    }
-
-
-type alias Event =
-    { precinct : String
-    , lesson : Int
-    , event_type : String
-    , canonical_student_id : Int
-    , activity : Int
-    }
-
-
-type alias Quanta =
-    { progress : Progress
-    , event : Event
-    }
-
-
 type alias Model =
-    { quantas : List Quanta
+    { quanta : Quanta
     , studentId : String
     , mdl : Material.Model
     }
 
 
-initialModel : Model
-initialModel =
-    { quantas = []
-    , studentId = "1"
-    , mdl = Material.model
-    }
-
-
 init : ( Model, Cmd Msg )
 init =
-    ( initialModel
+    ( { quanta = Quanta.init
+      , studentId = "1"
+      , mdl = Material.model
+      }
     , Cmd.none
     )
 
@@ -84,10 +57,10 @@ update : Msg -> Model -> ( Model, Cmd Msg )
 update msg model =
     case msg of
         GetEvents ->
-            { model | quantas = [] } ! [ loadEvents model.studentId ]
+            ( model, loadEvents model.studentId )
 
-        FetchSucceed quantas ->
-            ( { model | quantas = quantas }, Cmd.none )
+        FetchSucceed quanta ->
+            ( { model | quanta = quanta }, Cmd.none )
 
         FetchFail error ->
             ( model, Cmd.none )
@@ -115,7 +88,7 @@ type alias Mdl =
 view : Model -> Html Msg
 view model =
     div [ style [ ( "padding", "2rem" ) ] ]
-        [ h4 [] [text "Eventful"]
+        [ h4 [] [ text "Eventful" ]
         , Textfield.render MDL
             [ 0 ]
             model.mdl
@@ -132,80 +105,19 @@ view model =
             ]
             [ text "Get History" ]
         , br [] []
-        , quantaTable (reverse model.quantas)
+        , Quanta.view model.quanta
         ]
         |> Material.Scheme.top
-
-
-quantaTable : List Quanta -> Html b
-quantaTable quantas =
-    Table.table []
-        [ Table.thead []
-            [ Table.tr []
-                [ Table.th [] [ text "Precinct" ]
-                , Table.th [] [ text "Event Type" ]
-                , Table.th [] [ text "Lesson" ]
-                , Table.th [] [ text "Activity" ]
-                , Table.th [] [ text "Map" ]
-                , Table.th [] [ text "Position" ]
-                , Table.th [] [ text "Activity" ]
-                , Table.th [] [ text "Placement Test" ]
-                ]
-            ]
-        , tbody []
-            (List.map quantaView quantas)
-        ]
-
-
-quantaView : Quanta -> Html b
-quantaView quanta =
-    Table.tr []
-        [ Table.td [] [ text quanta.event.precinct ]
-        , Table.td [] [ text quanta.event.event_type ]
-        , Table.td [ Table.numeric ] [ text (toString quanta.event.lesson) ]
-        , Table.td [ Table.numeric ] [ text (toString quanta.event.activity) ]
-        , Table.td [ Table.numeric ] [ strong [] [ text (toString quanta.progress.map) ] ]
-        , Table.td [] [ strong [] [ text quanta.progress.position ] ]
-        , Table.td [ Table.numeric ] [ strong [] [ text (toString quanta.progress.activity) ] ]
-        , Table.td [] [ strong [] [ text (toString quanta.progress.placement_test) ] ]
-        ]
 
 
 loadEvents : String -> Cmd Msg
 loadEvents studentId =
     let
         url =
-          -- "http://progression.coreos-staging.blakedev.com/history/maths/my_lessons/" ++ studentId
-          "http://localhost:4000/api/v3/history/maths/my_lessons/" ++ studentId
-          -- "http://ex-seeds.coreos-staging.blakedev.com/api/v3/history/" ++ studentId
+            "http://progression.coreos-staging.blakedev.com/api/v3/history/maths/my_lessons/" ++ studentId
 
+        --          "http://localhost:4000/api/v3/history/maths/my_lessons/" ++ studentId
         decoder =
-            Json.list decodeQuanta
+            Quanta.decoder
     in
         Task.perform FetchFail FetchSucceed (Http.get decoder url)
-
-
-decodeProgress : Json.Decoder Progress
-decodeProgress =
-    decode Progress
-        |> JsonPipeline.required "position" string
-        |> JsonPipeline.required "placement_test" bool
-        |> JsonPipeline.required "map" int
-        |> JsonPipeline.required "activity" int
-
-
-decodeEvent : Json.Decoder Event
-decodeEvent =
-    decode Event
-        |> JsonPipeline.required "precinct" string
-        |> JsonPipeline.required "lesson" int
-        |> JsonPipeline.required "event_type" string
-        |> JsonPipeline.required "canonical_student_id" int
-        |> JsonPipeline.optional "activity" int 0
-
-
-decodeQuanta : Json.Decoder Quanta
-decodeQuanta =
-    decode Quanta
-        |> JsonPipeline.required "progress" decodeProgress
-        |> JsonPipeline.required "event" decodeEvent

--- a/Progress.elm
+++ b/Progress.elm
@@ -1,0 +1,21 @@
+module Progress exposing (..)
+
+import Json.Decode as Json exposing ((:=), string, int, bool, list)
+import Json.Decode.Pipeline as JsonPipeline exposing (decode, required)
+
+
+type alias Progress =
+    { position : String
+    , placement_test : Bool
+    , map : Int
+    , activity : Int
+    }
+
+
+decoder : Json.Decoder Progress
+decoder =
+    decode Progress
+        |> JsonPipeline.required "position" string
+        |> JsonPipeline.required "placement_test" bool
+        |> JsonPipeline.required "map" int
+        |> JsonPipeline.required "activity" int

--- a/Quanta.elm
+++ b/Quanta.elm
@@ -1,0 +1,72 @@
+module Quanta exposing (Quanta, init, decoder, view)
+
+import Html exposing (..)
+import Html.App exposing (..)
+import Html.Attributes exposing (..)
+import Json.Decode as JD exposing ((:=), string, int, bool, list)
+import Json.Decode.Pipeline as JsonPipeline exposing (decode, required)
+import Material.Table as Table
+import Event exposing (..)
+import Progress exposing (..)
+
+
+type Quanta
+    = A (List Model)
+
+
+type alias Model =
+    { progress : Progress
+    , event : Event
+    }
+
+
+init : Quanta
+init =
+    A []
+
+
+decoder : JD.Decoder Quanta
+decoder =
+    decode Model
+        |> JsonPipeline.required "progress" Progress.decoder
+        |> JsonPipeline.required "event" Event.decoder
+        |> JD.list
+        |> JD.map (\model -> A model)
+
+
+
+-- View
+
+
+view : Quanta -> Html b
+view (A quanta) =
+    Table.table []
+        [ Table.thead []
+            [ Table.tr []
+                [ Table.th [] [ text "Precinct" ]
+                , Table.th [] [ text "Event Type" ]
+                , Table.th [] [ text "Lesson" ]
+                , Table.th [] [ text "Activity" ]
+                , Table.th [] [ text "Map" ]
+                , Table.th [] [ text "Position" ]
+                , Table.th [] [ text "Activity" ]
+                , Table.th [] [ text "Placement Test" ]
+                ]
+            ]
+        , tbody []
+            (List.map rowView quanta)
+        ]
+
+
+rowView : Model -> Html b
+rowView { event, progress } =
+    Table.tr []
+        [ Table.td [] [ text event.precinct ]
+        , Table.td [] [ text event.event_type ]
+        , Table.td [ Table.numeric ] [ text (toString event.lesson) ]
+        , Table.td [ Table.numeric ] [ text (toString event.activity) ]
+        , Table.td [ Table.numeric ] [ strong [] [ text (toString progress.map) ] ]
+        , Table.td [] [ strong [] [ text progress.position ] ]
+        , Table.td [ Table.numeric ] [ strong [] [ text (toString progress.activity) ] ]
+        , Table.td [] [ strong [] [ text (toString progress.placement_test) ] ]
+        ]


### PR DESCRIPTION
This literally moves the event and progress decoders into their own modules along with their types.

It also converts Quanta into a TEA module with a opaque Quanta type.

I've incorporated the Quanta -> Quantum correction from https://github.com/blake-education/eventful/pull/2 but this PR makes much more drastic changes so the other PR should be closed.