### PR TITLE
Bugfix/fix current tab

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,1 +1,2 @@
+- Fix bug where current tab isn't indicated
 - Add simple loading indicator to 'Get History' button

--- a/Eventful/Update.elm
+++ b/Eventful/Update.elm
@@ -46,13 +46,13 @@ update msg model =
         SelectTab tab ->
             case tab of
                 0 ->
-                    ( { model | currentPage = Index }, Cmd.none )
+                    ( { model | currentPage = Index, tab = tab }, Cmd.none )
 
                 1 ->
-                    ( { model | currentPage = Settings }, Cmd.none )
+                    ( { model | currentPage = Settings, tab = tab  }, Cmd.none )
 
                 _ ->
-                    ( { model | currentPage = Index }, Cmd.none )
+                    ( { model | currentPage = Index, tab = tab  }, Cmd.none )
 
         _ ->
             ( model, Cmd.none )


### PR DESCRIPTION
Fixes issue where current tab was not indicated.

Here's what it looks like when on the settings tab with the fix applied:

<img width="597" alt="settings_page" src="https://cloud.githubusercontent.com/assets/19683715/19703864/2e2bfba8-9b51-11e6-9ced-6b7456121d2b.png">
